### PR TITLE
Add product rendering

### DIFF
--- a/app/code/community/Manners/Widgets/Block/Products.php
+++ b/app/code/community/Manners/Widgets/Block/Products.php
@@ -48,6 +48,6 @@ class Manners_Widgets_Block_Products extends Mage_Catalog_Block_Product implemen
     public function getPriceHtml(Mage_Catalog_Model_Product $oProduct)
     {
         $oProductBlock = $this->getLayout()->createBlock('catalog/product_price');
-        echo $oProductBlock->getPriceHtml($oProduct, true);
+        return $oProductBlock->getPriceHtml($oProduct, true);
     }
 }

--- a/app/code/community/Manners/Widgets/Block/Products.php
+++ b/app/code/community/Manners/Widgets/Block/Products.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @category    Manners
+ * @package     Manners_Widgets
+ * @copyright   Copyright (c) David Manners (http://davidmanners.de/)
+ */
+
+class Manners_Widgets_Block_Products extends Mage_Catalog_Block_Product implements Mage_Widget_Block_Interface
+{
+    private $oProductCollection;
+
+    /**
+     * Internal constructor
+     */
+    protected function _construct()
+    {
+        $this->oProductCollection = Mage::getModel('manners_widgets/collection_product');
+
+        $this->setTemplate('manners/products.phtml');
+        parent::_construct();
+    }
+
+    /**
+     * Gets a collection of predefined products
+     *
+     * @return \Mage_Catalog_Model_Resource_Product_Collection
+     * @throws \Mage_Core_Exception
+     */
+    public function getProductCollection()
+    {
+        $sProductIds = $this->getProductIds();
+
+        return $this->oProductCollection->getFilteredByProductIds($sProductIds);
+    }
+
+    /**
+     * Gets the price block to display with the selected products from
+     * the collection.
+     *
+     * Overwrites \Mage_Catalog_Block_Product::getPriceHtml in order
+     * to be able to build the price on no catalog pages.
+     *
+     * @param \Mage_Catalog_Model_Product $oProduct
+     *
+     * @return string
+     */
+    public function getPriceHtml(Mage_Catalog_Model_Product $oProduct)
+    {
+        $oProductBlock = $this->getLayout()->createBlock('catalog/product_price');
+        echo $oProductBlock->getPriceHtml($oProduct, true);
+    }
+}

--- a/app/code/community/Manners/Widgets/Model/Collection/Product.php
+++ b/app/code/community/Manners/Widgets/Model/Collection/Product.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @category    Manners
- * @package     Manners_Widgets
- * @copyright   Copyright (c) David Manners (http://davidmanners.de/)
- */
-
 class Manners_Widgets_Model_Collection_Product
 {
     private $oProductCollection;
@@ -30,17 +24,15 @@ class Manners_Widgets_Model_Collection_Product
         $aProductIds = array_map('intval', explode(',', $sProductIds));
 
         $this->addAttributesToCollection();
-        $this->addFiltersToCollection($aProductIds);
-        $this->addSortingToCollection($aProductIds);
+
+        $this->oProductCollection->addFieldToFilter('entity_id', array('in' => $aProductIds));
+
+        $sCollectionOrder = new Zend_Db_Expr('FIELD(e.entity_id, ' . implode(',', $aProductIds).')');
+        $this->oProductCollection->getSelect()->order($sCollectionOrder);
 
         return $this->oProductCollection;
     }
 
-    /**
-     * Add basic product attributes to collection
-     *
-     * @return $this
-     */
     private function addAttributesToCollection()
     {
         $this->oProductCollection->addAttributeToSelect(
@@ -49,41 +41,6 @@ class Manners_Widgets_Model_Collection_Product
         $this->oProductCollection->addMinimalPrice();
         $this->oProductCollection->addFinalPrice();
         $this->oProductCollection->addTaxPercents();
-        $this->oProductCollection->addWebsiteNamesToResult();
-        $this->oProductCollection->addTierPriceData();
-
-        return $this;
-    }
-
-    /**
-     * Add various filters to collection
-     *
-     * @param $aProductIds
-     *
-     * @return $this
-     */
-    private function addFiltersToCollection($aProductIds)
-    {
-        Mage::getSingleton('catalog/product_status')->addVisibleFilterToCollection($this->oProductCollection);
-        Mage::getSingleton('catalog/product_visibility')->addVisibleInCatalogFilterToCollection($this->oProductCollection);
-        $this->oProductCollection->addIdFilter($aProductIds);
-        $this->oProductCollection->addStoreFilter();
-        $this->oProductCollection->addWebsiteFilter();
-
-        return $this;
-    }
-
-    /**
-     * Add sorting through entity_id to collection
-     *
-     * @param $aProductIds
-     *
-     * @return $this
-     */
-    private function addSortingToCollection($aProductIds)
-    {
-        $sCollectionOrder = new Zend_Db_Expr('FIELD(entity_id, ' . implode(',', $aProductIds) . ')');
-        $this->oProductCollection->getSelect()->order($sCollectionOrder);
 
         return $this;
     }

--- a/app/code/community/Manners/Widgets/Model/Collection/Product.php
+++ b/app/code/community/Manners/Widgets/Model/Collection/Product.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @category    Manners
+ * @package     Manners_Widgets
+ * @copyright   Copyright (c) David Manners (http://davidmanners.de/)
+ */
+
+class Manners_Widgets_Model_Collection_Product
+{
+    private $oProductCollection;
+
+    /**
+     * constructor.
+     */
+    public function __construct()
+    {
+        $this->oProductCollection = Mage::getModel('catalog/product')->getCollection();
+    }
+
+    /**
+     * Returns a Product Collection filtered by passed product ids.
+     *
+     * @param string $sProductIds
+     *
+     * @return Mage_Catalog_Model_Resource_Product_Collection
+     */
+    public function getFilteredByProductIds($sProductIds)
+    {
+        $aProductIds = array_map('intval', explode(',', $sProductIds));
+
+        $this->addAttributesToCollection();
+        $this->addFiltersToCollection($aProductIds);
+        $this->addSortingToCollection($aProductIds);
+
+        return $this->oProductCollection;
+    }
+
+    /**
+     * Add basic product attributes to collection
+     *
+     * @return $this
+     */
+    private function addAttributesToCollection()
+    {
+        $this->oProductCollection->addAttributeToSelect(
+            Mage::getSingleton('catalog/config')->getProductAttributes()
+        );
+        $this->oProductCollection->addMinimalPrice();
+        $this->oProductCollection->addFinalPrice();
+        $this->oProductCollection->addTaxPercents();
+        $this->oProductCollection->addWebsiteNamesToResult();
+        $this->oProductCollection->addTierPriceData();
+
+        return $this;
+    }
+
+    /**
+     * Add various filters to collection
+     *
+     * @param $aProductIds
+     *
+     * @return $this
+     */
+    private function addFiltersToCollection($aProductIds)
+    {
+        Mage::getSingleton('catalog/product_status')->addVisibleFilterToCollection($this->oProductCollection);
+        Mage::getSingleton('catalog/product_visibility')->addVisibleInCatalogFilterToCollection($this->oProductCollection);
+        $this->oProductCollection->addIdFilter($aProductIds);
+        $this->oProductCollection->addStoreFilter();
+        $this->oProductCollection->addWebsiteFilter();
+
+        return $this;
+    }
+
+    /**
+     * Add sorting through entity_id to collection
+     *
+     * @param $aProductIds
+     *
+     * @return $this
+     */
+    private function addSortingToCollection($aProductIds)
+    {
+        $sCollectionOrder = new Zend_Db_Expr('FIELD(entity_id, ' . implode(',', $aProductIds) . ')');
+        $this->oProductCollection->getSelect()->order($sCollectionOrder);
+
+        return $this;
+    }
+}

--- a/app/code/community/Manners/Widgets/etc/config.xml
+++ b/app/code/community/Manners/Widgets/etc/config.xml
@@ -25,6 +25,12 @@
                 <class>Manners_Widgets_Helper</class>
             </manners_widgets>
         </helpers>
+
+        <models>
+            <manners_widgets>
+                <class>Manners_Widgets_Model</class>
+            </manners_widgets>
+        </models>
     </global>
 
     <admin>

--- a/app/design/frontend/base/default/template/manners/products.phtml
+++ b/app/design/frontend/base/default/template/manners/products.phtml
@@ -1,0 +1,35 @@
+<?php
+$oProductCollection = $this->getProductCollection();
+$oOutputHelper      = $this->helper('catalog/output');
+$oProductHelper     = $this->helper('catalog/product');
+?>
+
+<div class="products__list" id="products-list">
+    <?php $iIterator = 0; ?>
+    <?php foreach ($oProductCollection as $oProduct): ?>
+        <div class="item<?php if (++$iIterator == sizeof($oProductCollection)): ?> last<?php endif; ?>  products__list-item">
+            <?php // Product Image ?>
+            <a href="<?php echo $oProduct->getProductUrl() ?>"
+               title="<?php echo $this->stripTags($this->getImageLabel($oProduct, 'small_image'), null, true) ?>"
+               class="product__image">
+                <img src="<?php echo $this->helper('catalog/image')->init($oProduct, 'small_image')->resize(275); ?>"
+                     alt="<?php echo $this->stripTags($this->getImageLabel($oProduct, 'small_image'), null, true) ?>"/>
+            </a>
+            <?php // Product description ?>
+            <div class="product__shop">
+                <?php $sProductNameStripped = $this->stripTags($oProduct->getName(), null, true); ?>
+                <h2 class="product__name">
+                    <a href="<?php echo $oProduct->getProductUrl() ?>"
+                       title="<?php echo $sProductNameStripped; ?>">
+                        <?php echo $oOutputHelper->productAttribute($oProduct, $oProduct->getName(), 'name'); ?>
+                    </a>
+                </h2>
+                <?php if ($oProduct->hasShortDescription()): ?>
+                    <p class="product__short-description"><?php echo $oOutputHelper->productAttribute($oProduct, $oProduct->getShortDescription(), 'short_description') ?></p>
+                <?php endif; ?>
+                <?php $productObject = Mage::getModel('catalog/product')->load($oProduct->getId());?>
+                <?php echo $this->getPriceHtml($productObject) ?>
+            </div>
+        </div>
+    <?php endforeach; ?>
+</div>

--- a/app/etc/modules/Manners_Widgets.xml
+++ b/app/etc/modules/Manners_Widgets.xml
@@ -18,6 +18,7 @@
 			<codePool>community</codePool>
 			<depends>
 				<Mage_Adminhtml />
+				<Mage_Catalog />
 				<Mage_Widget />
 			</depends>
 		</Manners_Widgets>

--- a/modman
+++ b/modman
@@ -1,4 +1,6 @@
 app/code/community/Manners/Widgets                              app/code/community/Manners/Widgets
 app/etc/modules/Manners_Widgets.xml                             app/etc/modules/Manners_Widgets.xml
-app/design/adminhtml/default/default/layout/manners/widgets.xml app/design/adminhtml/default/default/layout/manners/widgets.xml
 js/manners/adminhtml/widgets.js                                 js/manners/adminhtml/widgets.js
+
+app/design/adminhtml/default/default/layout/manners/widgets.xml   app/design/adminhtml/default/default/layout/manners/widgets.xml
+app/design/frontend/base/default/template/manners/products.phtml  app/design/frontend/base/default/template/manners/products.phtml


### PR DESCRIPTION
# Description

After having the multiple product select in place, we needed a way to show those selected products. For we created a block with functionality needed for rendering the template, as well as a collection to load the selected products.
# Changes
- Added `Manners_Widgets_Block_Products::getProductCollection` to get the collection of selected products inside the template
- Overwritten `\Mage_Catalog_Block_Product::getPriceHtml` as `Manners_Widgets_Block_Products::getPriceHtml` to be able to render prices correctly
- Added `Manners_Widgets_Model_Collection_Product` collection to properly load and filter products as per Magento default functionality
- Added template with basic rendering data: Name, short description and price
- Changed `.modman` to add new file entry
