### PR TITLE
Add product visibility filter to collection

### DIFF
--- a/app/code/community/Manners/Widgets/Model/Collection/Product.php
+++ b/app/code/community/Manners/Widgets/Model/Collection/Product.php
@@ -26,7 +26,7 @@ class Manners_Widgets_Model_Collection_Product
         $this->addAttributesToCollection();
 
         $this->oProductCollection->addFieldToFilter('entity_id', array('in' => $aProductIds));
-        $this->oProductCollection->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH);
+        $this->oProductCollection->setVisibility(Mage::getSingleton('catalog/product_visibility')->getVisibleInCatalogIds());
 
         $sCollectionOrder = new Zend_Db_Expr('FIELD(e.entity_id, ' . implode(',', $aProductIds).')');
         $this->oProductCollection->getSelect()->order($sCollectionOrder);

--- a/app/code/community/Manners/Widgets/Model/Collection/Product.php
+++ b/app/code/community/Manners/Widgets/Model/Collection/Product.php
@@ -26,6 +26,7 @@ class Manners_Widgets_Model_Collection_Product
         $this->addAttributesToCollection();
 
         $this->oProductCollection->addFieldToFilter('entity_id', array('in' => $aProductIds));
+        $this->oProductCollection->setVisibility(Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH);
 
         $sCollectionOrder = new Zend_Db_Expr('FIELD(e.entity_id, ' . implode(',', $aProductIds).')');
         $this->oProductCollection->getSelect()->order($sCollectionOrder);


### PR DESCRIPTION
# Description

Collections should behave the same way through out Magento. As per this, we need to ensure that only products allowed to show on catalog and/or search results should be able to show, even if someone selects a product that should not be shown.
# Changes
- Added visibility filter to collection to avoid showing products that should not be shown by themselves (like associated products of configurable products set to not show)
